### PR TITLE
fix: support non float subscription request IDs

### DIFF
--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -55,7 +55,7 @@ type WebsocketsServer interface {
 type SubscriptionResponseJSON struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Result  interface{} `json:"result"`
-	ID      float64     `json:"id"`
+	ID      interface{} `json:"id,omitempty"`
 }
 
 type SubscriptionNotification struct {
@@ -225,11 +225,11 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 			continue
 		}
 
-		connID, ok := msg["id"].(float64)
+		connID, ok := msg["id"]
 		if !ok {
 			s.sendErrResponse(
 				wsConn,
-				fmt.Errorf("invalid type for connection ID: %T", msg["id"]).Error(),
+				"missing required connection ID",
 			)
 			continue
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Supports non-float64 JSON-RPC ID when handling websocket requests. Many tools and example docs for evm API use a quoted number or some other string, which was being rejected.

From the [JSON-RPC 2.0](https://www.jsonrpc.org/specification)
> id
An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [[1]](https://www.jsonrpc.org/specification#id1) and Numbers SHOULD NOT contain fractional parts [[2]](https://www.jsonrpc.org/specification#id2)
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
  - existing tests pass, changed variable is only used within the limited scope of the modified function
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/ethermint/21)
<!-- Reviewable:end -->
