### PR TITLE
fix(rpc): eth_feeHistory base fee cannot be null

### DIFF
--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -223,6 +223,15 @@ func (b *Backend) FeeHistory(
 			return nil, err
 		}
 
+		// the eth rpc spec requires a hex string to be returned for these values, so if they are nil then default them to 0x0
+		if oneFeeHistory.BaseFee == nil {
+			oneFeeHistory.BaseFee = big.NewInt(0)
+		}
+
+		if oneFeeHistory.NextBaseFee == nil {
+			oneFeeHistory.NextBaseFee = big.NewInt(0)
+		}
+
 		// copy
 		thisBaseFee[index] = (*hexutil.Big)(oneFeeHistory.BaseFee)
 		thisBaseFee[index+1] = (*hexutil.Big)(oneFeeHistory.NextBaseFee)


### PR DESCRIPTION
`eth_feeHistory` requires `baseFeePerGas` to be a list of hex-encoded u256.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/ethermint/25)
<!-- Reviewable:end -->
